### PR TITLE
functions now mutate the original moment instance. no use of clone()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# moment-business (v1.0.1)
+# moment-business (v2.0.0)
 
 momnet-business is an extension library for [Momentjs](http://momentjs.com/), with customiztion under US Federal Holidays and weekends.
 
-## Build Status 
+## Build Status
 [![Circle build status](https://circleci.com/gh/dstyle28/moment_business.svg?style=shield)](https://circleci.com/gh/dstyle28/moment_business)
 
 ## Code Climate Status
@@ -13,25 +13,25 @@ momnet-business is an extension library for [Momentjs](http://momentjs.com/), wi
 
 ##### `holidaysBetween(moment_date)`
 	Find holidays between moment and moment_date
-	@param moment_date: {moment} 
+	@param moment_date: {moment}
 	@return {Array}
 
 ##### `holidayDiff(moment_date)`
 	Calculate number(s) of holidays between moment and moment_date
-	@param moment_date: {moment} 
+	@param moment_date: {moment}
 	@return {int} - postive if moment < moment_date
 	              - negative if moment > moment_date
 	              - 0 if moment = moment_date
-	
+
 ##### `businessDiff(moment_date)`
 	Calculate number(s) of business days between moment and moment_date
-	@param moment_date: {moment} 
+	@param moment_date: {moment}
 	@return {int} - postive if moment < moment_date
 	              - negative if moment > moment_date
 	              - 0 if moment = moment_date
-	              
+
 ##### `isWeekday()`
-	Determine if moment is week day	
+	Determine if moment is week day
 	@return {boolean}
 
 ##### `isBusinessDay()`

--- a/src/moment-business.js
+++ b/src/moment-business.js
@@ -145,26 +145,25 @@ var US_FEDERAL_HOLIDAYS = [
 			window.console && console.error('Unknown sign (' + sign + ').');
 			return;
 		}
-		var date = this.clone();
 		var signal = sign === '+' ? 1 : -1;
 		signal = days < 0 ? signal * -1 : signal;
 		var offset = Math.abs(days);
 
 		if (offset === 0){
 			// If give day is holiday or weekend.
-			while(!date.isBusinessDay()) {
-				date = date.add(signal, 'days');
+			while(!this.isBusinessDay()) {
+				this.add(signal, 'days');
 			}
 		}
 		else {
 			while (offset !== 0) {
-				date = date.add(signal, 'days');
-				if(date.isBusinessDay()) {
+				this.add(signal, 'days');
+				if(this.isBusinessDay()) {
 					offset-- ;
 				}
 			}
 		}
-		return date;
+		return this;
 	};
 
 	/**
@@ -183,8 +182,7 @@ var US_FEDERAL_HOLIDAYS = [
 	 * @returns {moment} - next business day from {moment} *this*
 	 */
 	moment.fn.nextBusinessDay = function() {
-		var date = this.clone();
-		return date.addBusinessDay(1);
+		return this.addBusinessDay(1);
 	};
 
 	/**
@@ -193,8 +191,7 @@ var US_FEDERAL_HOLIDAYS = [
 	 * @returns {moment} - previous business day from {moment} *this*
 	 */
 	moment.fn.previousBusinessDay = function() {
-		var date = this.clone();
-		return date.subtractBusinessDay(1);
+		return this.subtractBusinessDay(1);
 	};
 
 }).call(this);

--- a/test/test_add_substract_business_day.js
+++ b/test/test_add_substract_business_day.js
@@ -20,6 +20,16 @@ describe("Test for add business days", function() {
 	it("Unknown operation sign", function() {
 		expect(moment('2015-4-1', 'YYYY-M-D').addBusinessDay(1, 'unknown')).toBe();
 	});
+	it("mutates the original moment object", function() {
+		var febOne = moment('2016-2-1', 'YYYY-M-D');
+		febOne.addBusinessDay(1);
+		expect(febOne.format('YYYY-M-D')).toBe('2016-2-2');
+	});
+	it("allows for method chaining", function() {
+		var febOne = moment('2016-2-1', 'YYYY-M-D');
+		febOne.addBusinessDay(1).addBusinessDay(2);
+		expect(febOne.format('YYYY-M-D')).toBe('2016-2-4');
+	});
 });
 
 describe("Test for subtract business days", function() {

--- a/test/test_next_previous_business_day.js
+++ b/test/test_next_previous_business_day.js
@@ -23,6 +23,11 @@ describe("Test for next business days", function() {
     it("Holiday is Weekend", function() {
         expect(moment('2017-1-1', 'YYYY-M-D').nextBusinessDay().format('YYYY-M-D')).toBe('2017-1-3');
     });
+    it("mutates the original moment object", function() {
+        var febOne = moment('2016-2-1', 'YYYY-M-D');
+        febOne.nextBusinessDay();
+        expect(febOne.format('YYYY-M-D')).toBe('2016-2-2');
+    });
 });
 
 
@@ -47,5 +52,10 @@ describe("Test for previous business days", function() {
     });
     it("Tuesday with Monday is holiday", function() {
         expect(moment('2017-1-3', 'YYYY-M-D').previousBusinessDay().format('YYYY-M-D')).toBe('2016-12-30');
+    });
+    it("mutates the original moment object", function() {
+        var febOne = moment('2016-2-1', 'YYYY-M-D');
+        febOne.previousBusinessDay();
+        expect(febOne.format('YYYY-M-D')).toBe('2016-1-29');
     });
 });


### PR DESCRIPTION
- removed every instance of `this.clone()`. This means that all moment-business functions now mutate the original instance, which is consistent with `moment.add()` and `moment.substract()`
- added additional test coverage
- updated to `v2.0.0` in the readMe
